### PR TITLE
Remove Lakeview Urbanists references from codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Python-based data pipeline that ingests, validates, and serves Chicago traffic
 
 The service orchestrates end-to-end ETL for four interconnected datasets from the Chicago Open Data Portal, keeps them synchronized in PostgreSQL/PostGIS, and exposes a FastAPI layer with an admin UI and documentation.
 
-**Now includes a full-stack public dashboard** built with Next.js, featuring interactive maps, trend charts, and real-time statistics - perfect for advocacy organizations like [Lakeview Urbanists](https://lakeviewurbanists.org).
+**Now includes a full-stack public dashboard** built with Next.js, featuring interactive maps, trend charts, and real-time statistics.
 
 ## Quick Start
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,6 @@
 # Chicago Crash Dashboard
 
-Public dashboard for visualizing Chicago traffic crash data. Built by [Lakeview Urbanists](https://lakeviewurbanists.org).
+Public dashboard for visualizing Chicago traffic crash data from the Chicago Open Data Portal.
 
 ## Features
 
@@ -103,4 +103,3 @@ MIT License - see LICENSE file in the main repository.
 ## Credits
 
 - Data: [Chicago Open Data Portal](https://data.cityofchicago.org)
-- Organization: [Lakeview Urbanists](https://lakeviewurbanists.org)

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "Chicago Crash Dashboard | Lakeview Urbanists",
+  title: "Main Dashboard",
   description:
     "Public dashboard visualizing Chicago traffic crash data. Explore patterns, trends, and safety insights across Chicago neighborhoods.",
   openGraph: {
@@ -42,14 +42,6 @@ export default function RootLayout({
                 >
                   Location Report
                 </Link>
-                <a
-                  href="https://lakeviewurbanists.org"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium"
-                >
-                  Lakeview Urbanists
-                </a>
               </div>
             </div>
           </nav>
@@ -58,7 +50,7 @@ export default function RootLayout({
         <footer className="bg-gray-100 dark:bg-gray-900 py-8 mt-auto">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center text-sm text-gray-600 dark:text-gray-400">
             <p>
-              Data from{" "}
+Data from{" "}
               <a
                 href="https://data.cityofchicago.org"
                 target="_blank"
@@ -67,20 +59,11 @@ export default function RootLayout({
               >
                 Chicago Open Data Portal
               </a>
-              . Built by{" "}
-              <a
-                href="https://lakeviewurbanists.org"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="underline hover:text-gray-900 dark:hover:text-gray-200"
-              >
-                Lakeview Urbanists
-              </a>
               .
             </p>
             <p className="mt-2">
               <a
-                href="https://github.com/lakeview-urbanists/chicago-crash-dashboard"
+                href="https://github.com/MisterClean/chicago-crashes-pipeline"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="underline hover:text-gray-900 dark:hover:text-gray-200"

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -20,7 +20,7 @@ export default function Home() {
               View Dashboard
             </Link>
             <a
-              href="https://github.com/lakeview-urbanists/chicago-crash-dashboard"
+              href="https://github.com/MisterClean/chicago-crashes-pipeline"
               target="_blank"
               rel="noopener noreferrer"
               className="rounded-md bg-gray-100 dark:bg-gray-700 px-6 py-3 text-lg font-semibold text-gray-900 dark:text-white shadow-sm hover:bg-gray-200 dark:hover:bg-gray-600"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "chicago-crash-dashboard",
   "version": "0.1.0",
   "private": true,
-  "description": "Public dashboard for Chicago traffic crash data - by Lakeview Urbanists",
+  "description": "Public dashboard for Chicago traffic crash data",
   "scripts": {
     "dev": "next dev -p 3001",
     "build": "next build",
@@ -36,7 +36,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/lakeview-urbanists/chicago-crash-dashboard"
+    "url": "https://github.com/MisterClean/chicago-crashes-pipeline"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- Removes all 10 "Lakeview Urbanists" references across 5 files
- Changes page title to "Main Dashboard"
- Removes org-specific nav link and footer credits
- Updates GitHub URLs to MisterClean/chicago-crashes-pipeline

Makes the app generic and deployment-agnostic so anyone can deploy for their own purposes.

Closes #27

## Test plan
- [ ] Verify frontend builds without errors
- [ ] Check page title shows "Main Dashboard"
- [ ] Confirm nav header no longer has org link
- [ ] Verify footer only shows Chicago Open Data Portal credit
- [ ] Check GitHub links point to correct repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)