### PR TITLE
Fix misleading radius dropdown default

### DIFF
--- a/frontend/app/dashboard/location-report/page.tsx
+++ b/frontend/app/dashboard/location-report/page.tsx
@@ -308,15 +308,23 @@ export default function LocationReportPage() {
                     }}
                     className="flex-1 h-2 bg-gray-200 dark:bg-gray-600 rounded-lg appearance-none cursor-pointer accent-blue-600"
                   />
-                  {/* Custom input */}
+                  {/* Custom input - shows slider value in grey, user input in normal color */}
                   <input
                     type="number"
                     min="25"
                     max="26400"
                     placeholder="ft"
-                    value={customRadiusInput}
+                    value={customRadiusInput || selectedRadius}
                     onChange={(e) => handleCustomRadiusChange(e.target.value)}
-                    className="w-16 px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-xs text-center"
+                    onFocus={(e) => {
+                      // Select all text on focus for easy replacement
+                      e.target.select();
+                    }}
+                    className={`w-16 px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-xs text-center ${
+                      customRadiusInput
+                        ? "text-gray-900 dark:text-gray-100"
+                        : "text-gray-400 dark:text-gray-500"
+                    }`}
                   />
                 </div>
                 {/* Tick marks */}


### PR DESCRIPTION
## Summary

Fixes the misleading radius dropdown on the location report page and replaces it with an improved slider UI.

### Changes
- **Replace dropdown with continuous slider** - Logarithmic scale from 25ft to 10,560ft (2 miles) for smooth, intuitive radius selection
- **Realtime map updates** - Circle on map resizes instantly as you drag the slider
- **Default to 200ft** - Sensible default that matches the displayed value
- **Always display in feet** - Consistent units, no confusing feet/miles switching
- **Smart custom input** - Shows current slider value in grey, turns normal when user enters custom value, auto-selects on focus

### Before
- Dropdown showed "50 ft" but actual radius was 1320ft (mismatch)
- Only preset values available
- Map circle did not update until report was generated

### After
- Slider position always matches displayed radius
- Smooth continuous values with logarithmic scale
- Map circle updates in realtime as slider moves
- Custom input field for precise values

## Test plan
- [ ] Load location report page, verify slider shows "200 ft" by default
- [ ] Drag slider and verify circle on map resizes in realtime
- [ ] Verify radius display stays in feet throughout the range
- [ ] Click custom input, verify it is pre-filled with slider value in grey
- [ ] Type a custom value, verify text turns normal color and circle updates

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)