### PR TITLE
Add loading indicator to location report

### DIFF
--- a/frontend/app/dashboard/location-report/page.tsx
+++ b/frontend/app/dashboard/location-report/page.tsx
@@ -441,7 +441,33 @@ export default function LocationReportPage() {
                       : "bg-gray-300 dark:bg-gray-600 text-gray-500 dark:text-gray-400 cursor-not-allowed"
                   }`}
                 >
-                  {loading ? "..." : "Generate"}
+                  {loading ? (
+                    <span className="flex items-center justify-center gap-2">
+                      <svg
+                        className="animate-spin h-4 w-4"
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                      >
+                        <circle
+                          className="opacity-25"
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke="currentColor"
+                          strokeWidth="4"
+                        />
+                        <path
+                          className="opacity-75"
+                          fill="currentColor"
+                          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                        />
+                      </svg>
+                      Generating...
+                    </span>
+                  ) : (
+                    "Generate"
+                  )}
                 </button>
               </div>
             </div>
@@ -458,6 +484,37 @@ export default function LocationReportPage() {
             )}
           </div>
         </div>
+
+        {/* Loading Indicator */}
+        {loading && (
+          <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4 mb-8">
+            <div className="flex items-center gap-3">
+              <svg
+                className="animate-spin h-5 w-5 text-blue-600 dark:text-blue-400"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                />
+              </svg>
+              <p className="text-blue-800 dark:text-blue-200 font-medium">
+                Generating report... This may take a few seconds.
+              </p>
+            </div>
+          </div>
+        )}
 
         {/* Error Message */}
         {error && (


### PR DESCRIPTION
## Summary
- Adds animated spinner to Generate button when report is loading
- Adds blue notification banner below controls showing "Generating report... This may take a few seconds."
- Both indicators support dark mode styling

Closes #36

## Test plan
- [ ] Click Generate with a valid selection and verify spinner appears in button
- [ ] Verify blue loading banner appears below controls
- [ ] Check dark mode styling works correctly
- [ ] Verify indicators disappear when report loads or error occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)