### PR TITLE
Add active state styling to date preset buttons

### DIFF
--- a/frontend/app/dashboard/location-report/page.tsx
+++ b/frontend/app/dashboard/location-report/page.tsx
@@ -61,6 +61,9 @@ export default function LocationReportPage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Store the date range used for the current report (so panel doesn't update in real-time)
+  const [reportDateRange, setReportDateRange] = useState<{ start: string; end: string } | null>(null);
+
   // Date filter state - default to last 30 days
   const [startDate, setStartDate] = useState(defaultDates.startDate);
   const [endDate, setEndDate] = useState(defaultDates.endDate);
@@ -201,6 +204,7 @@ export default function LocationReportPage() {
 
       const result = await fetchLocationReport(request);
       setReport(result);
+      setReportDateRange({ start: startDate, end: endDate });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to generate report");
     } finally {
@@ -215,6 +219,7 @@ export default function LocationReportPage() {
     setSelectedPlaceId(null);
     setSelectedPlaceGeometry(null);
     setReport(null);
+    setReportDateRange(null);
     setError(null);
   };
 
@@ -554,8 +559,8 @@ export default function LocationReportPage() {
             onCenterSelect={handleCenterSelect}
             onPolygonComplete={setSelectedPolygon}
             reportData={report}
-            startDate={startDate}
-            endDate={endDate}
+            startDate={reportDateRange?.start ?? ""}
+            endDate={reportDateRange?.end ?? ""}
           />
         </div>
 


### PR DESCRIPTION
## Summary
- Date preset buttons (7d, 30d, 90d, 1yr, All) now highlight in blue when selected
- Matches the existing selection mode button behavior for visual consistency
- Active preset clears when users manually edit the date inputs
- Map stats panel now shows the date range from the generated report, not real-time updates

Fixes #35

## Test plan
- [ ] Click each date preset button and verify it turns blue
- [ ] Click a different preset and verify the previous one returns to gray
- [ ] Manually change a date input and verify all presets return to gray
- [ ] Generate a report, then change the date inputs - verify the map panel still shows the original date range
- [ ] Verify dark mode styling works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)