### PR TITLE
Fix: Add location report endpoint to public routes

### DIFF
--- a/src/api/middleware/auth.py
+++ b/src/api/middleware/auth.py
@@ -24,6 +24,7 @@ DEFAULT_PUBLIC_ROUTES = [
     "/dashboard/stats",
     "/dashboard/trends",
     "/dashboard/crashes/geojson",
+    "/dashboard/location-report",
     # Places API (read-only geographic data)
     "/places/",
     # Static assets

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -48,6 +48,14 @@ class TestIsPublicRoute:
         assert is_public_route("/dashboard/trends") is True
         assert is_public_route("/dashboard/crashes/geojson") is True
 
+    def test_dashboard_location_report_is_public(self):
+        """Location report endpoint should be public (read-only crash data)."""
+        assert is_public_route("/dashboard/location-report") is True
+
+    def test_dashboard_location_report_export_is_protected(self):
+        """Location report export should require authentication."""
+        assert is_public_route("/dashboard/location-report/export") is False
+
     def test_places_endpoints_are_public(self):
         """Places API endpoints should be public."""
         assert is_public_route("/places/") is True
@@ -71,7 +79,6 @@ class TestIsPublicRoute:
     def test_unprotected_non_public_routes_require_auth(self):
         """Routes not in public list should require authentication."""
         assert is_public_route("/spatial/load") is False
-        assert is_public_route("/dashboard/location-report") is False
         assert is_public_route("/sync/counts") is False
         assert is_public_route("/some/random/path") is False
         assert is_public_route("/api/private") is False
@@ -314,7 +321,6 @@ class TestSecurityVulnerabilityRegression:
         # These should NOT be public even though they all start with "/"
         non_public_paths = [
             "/spatial/load",
-            "/dashboard/location-report",
             "/sync/counts",
             "/api/internal",
             "/arbitrary/endpoint",


### PR DESCRIPTION
## Summary

- Add `/dashboard/location-report` to public routes in API key middleware
- The location report generates crash statistics for a given area - this is read-only public data
- The export endpoint (`/dashboard/location-report/export`) remains protected

## Problem

After deploying the API key authentication middleware (PR #50), the location report "Generate" button on the production frontend started returning "Failed to fetch" errors.

**Root cause:** The frontend makes client-side requests to `/dashboard/location-report`, but the API key is only included in server-side requests. Since this endpoint wasn't in the public routes list, it was returning 401 Unauthorized.

## Solution

Add `/dashboard/location-report` to `DEFAULT_PUBLIC_ROUTES` alongside other public dashboard endpoints (`/dashboard/stats`, `/dashboard/trends`, `/dashboard/crashes/geojson`).

This is appropriate because:
1. The location report serves aggregated crash data - the same public data available through other dashboard endpoints
2. It's read-only and doesn't modify any data
3. The export endpoint (`/dashboard/location-report/export`) remains protected since that's a more resource-intensive operation

## Test plan

- [x] All 35 auth middleware tests pass
- [x] Added explicit test for `/dashboard/location-report` being public
- [x] Added explicit test for `/dashboard/location-report/export` remaining protected
- [ ] Verify location report works on production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)