### PR TITLE
Update severity colors to colorblind-safe palette

### DIFF
--- a/frontend/app/dashboard/components/TrendCharts.tsx
+++ b/frontend/app/dashboard/components/TrendCharts.tsx
@@ -73,8 +73,8 @@ export function TrendCharts({ data }: TrendChartsProps) {
           type="monotone"
           dataKey="fatalities"
           name="Fatalities"
-          stroke="#dc2626"
-          fill="#dc2626"
+          stroke="#440154"
+          fill="#440154"
           fillOpacity={0.3}
         />
       </AreaChart>

--- a/frontend/app/dashboard/location-report/components/LocationReportMap.tsx
+++ b/frontend/app/dashboard/location-report/components/LocationReportMap.tsx
@@ -350,12 +350,12 @@ export function LocationReportMap({
                 "circle-color": [
                   "case",
                   [">", ["get", "injuries_fatal"], 0],
-                  "#dc2626",
+                  "#440154",  // Deep Violet - Fatal
                   [">", ["get", "injuries_incapacitating"], 0],
-                  "#ea580c",
+                  "#E66100",  // Vermillion - Incapacitating
                   [">", ["get", "injuries_total"], 0],
-                  "#eab308",
-                  "#22c55e",
+                  "#56B4E9",  // Sky Blue - Other Injury
+                  "#CCCCCC",  // Light Grey - Property Damage Only
                 ],
                 "circle-opacity": 0.8,
                 "circle-stroke-width": 1,

--- a/frontend/app/dashboard/location-report/components/TrendSparklines.tsx
+++ b/frontend/app/dashboard/location-report/components/TrendSparklines.tsx
@@ -86,14 +86,14 @@ export function TrendSparklines({ data }: TrendSparklinesProps) {
           </p>
           <p className="text-xs text-gray-500 dark:text-gray-400">crashes</p>
         </div>
-        <div className="bg-yellow-50 dark:bg-yellow-900/20 rounded-lg p-3">
+        <div className="bg-sky-50 dark:bg-sky-900/20 rounded-lg p-3">
           <p className="text-xs text-gray-500 dark:text-gray-400">Avg/Month</p>
-          <p className="text-lg font-bold text-yellow-600">{avgInjuries}</p>
+          <p className="text-lg font-bold" style={{ color: "#56B4E9" }}>{avgInjuries}</p>
           <p className="text-xs text-gray-500 dark:text-gray-400">injuries</p>
         </div>
-        <div className="bg-red-50 dark:bg-red-900/20 rounded-lg p-3">
+        <div className="bg-violet-50 dark:bg-violet-900/20 rounded-lg p-3">
           <p className="text-xs text-gray-500 dark:text-gray-400">Total</p>
-          <p className="text-lg font-bold text-red-600">{totals.fatalities}</p>
+          <p className="text-lg font-bold" style={{ color: "#440154" }}>{totals.fatalities}</p>
           <p className="text-xs text-gray-500 dark:text-gray-400">fatalities</p>
         </div>
       </div>
@@ -144,8 +144,8 @@ export function TrendSparklines({ data }: TrendSparklinesProps) {
             <AreaChart data={data}>
               <defs>
                 <linearGradient id="injuryGradient" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="#eab308" stopOpacity={0.3} />
-                  <stop offset="95%" stopColor="#eab308" stopOpacity={0} />
+                  <stop offset="5%" stopColor="#56B4E9" stopOpacity={0.3} />
+                  <stop offset="95%" stopColor="#56B4E9" stopOpacity={0} />
                 </linearGradient>
               </defs>
               <XAxis
@@ -160,7 +160,7 @@ export function TrendSparklines({ data }: TrendSparklinesProps) {
               <Area
                 type="monotone"
                 dataKey="injuries"
-                stroke="#eab308"
+                stroke="#56B4E9"
                 strokeWidth={2}
                 fill="url(#injuryGradient)"
                 name="Injuries"
@@ -181,8 +181,8 @@ export function TrendSparklines({ data }: TrendSparklinesProps) {
               <AreaChart data={data}>
                 <defs>
                   <linearGradient id="fatalityGradient" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="5%" stopColor="#dc2626" stopOpacity={0.3} />
-                    <stop offset="95%" stopColor="#dc2626" stopOpacity={0} />
+                    <stop offset="5%" stopColor="#440154" stopOpacity={0.3} />
+                    <stop offset="95%" stopColor="#440154" stopOpacity={0} />
                   </linearGradient>
                 </defs>
                 <XAxis
@@ -197,7 +197,7 @@ export function TrendSparklines({ data }: TrendSparklinesProps) {
                 <Area
                   type="monotone"
                   dataKey="fatalities"
-                  stroke="#dc2626"
+                  stroke="#440154"
                   strokeWidth={2}
                   fill="url(#fatalityGradient)"
                   name="Fatalities"

--- a/frontend/lib/mapStyles.ts
+++ b/frontend/lib/mapStyles.ts
@@ -36,12 +36,12 @@ export const LOOP_VIEW_STATE = {
 export const MIN_ZOOM = 7; // Allow zooming out to see full Chicago metro area
 export const MAX_ZOOM = 18;
 
-// Severity legend for UI
+// Severity legend for UI - colorblind-safe palette
 export const SEVERITY_LEGEND = [
-  { label: "Fatal", color: "#dc2626" },
-  { label: "Incapacitating Injury", color: "#ea580c" },
-  { label: "Other Injury", color: "#eab308" },
-  { label: "Property Damage Only", color: "#22c55e" },
+  { label: "Fatal", color: "#440154" },              // Deep Violet
+  { label: "Incapacitating Injury", color: "#E66100" }, // Vermillion
+  { label: "Other Injury", color: "#56B4E9" },       // Sky Blue
+  { label: "Property Damage Only", color: "#CCCCCC" }, // Light Grey
 ];
 
 // Map metric options for user selection
@@ -65,12 +65,12 @@ export const MAP_METRICS: MetricConfig[] = [
     colorExpression: [
       "case",
       [">", ["get", "injuries_fatal"], 0],
-      "#dc2626",
+      "#440154",  // Deep Violet - Fatal
       [">", ["get", "injuries_incapacitating"], 0],
-      "#ea580c",
+      "#E66100",  // Vermillion - Incapacitating
       [">", ["get", "injuries_total"], 0],
-      "#eab308",
-      "#22c55e",
+      "#56B4E9",  // Sky Blue - Other Injury
+      "#CCCCCC",  // Light Grey - Property Damage Only
     ],
     getFilterExpression: (visible: Set<string>) => {
       const conditions: unknown[] = ["any"];

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -13,12 +13,12 @@ const config: Config = {
           blue: "#b3ddf2",
           red: "#cf142b",
         },
-        // Severity colors for crash data
+        // Severity colors for crash data - colorblind-safe palette
         severity: {
-          fatal: "#dc2626",
-          incapacitating: "#ea580c",
-          injury: "#eab308",
-          property: "#22c55e",
+          fatal: "#440154",        // Deep Violet
+          incapacitating: "#E66100", // Vermillion
+          injury: "#56B4E9",       // Sky Blue
+          property: "#CCCCCC",     // Light Grey
         },
       },
     },


### PR DESCRIPTION
## Summary
- Replaces red/orange/yellow/green severity colors with a colorblind-accessible palette
- Uses deep violet (#440154), vermillion (#E66100), sky blue (#56B4E9), and light grey (#CCCCCC)
- Updates map layers, trend charts, sparklines, and Tailwind theme configuration

## Color Palette
| Severity | Color | Hex |
|----------|-------|-----|
| Fatal | Deep Violet | `#440154` |
| Incapacitating | Vermillion | `#E66100` |
| Other Injury | Sky Blue | `#56B4E9` |
| Property Damage | Light Grey | `#CCCCCC` |

## Test plan
- [ ] Verify map crash points display with new colors
- [ ] Check severity legend matches new palette
- [ ] Verify trend sparklines use updated colors
- [ ] Test with colorblind simulation tools

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)