### PR TITLE
Redesign location report BAN cards with simplified color scheme

### DIFF
--- a/frontend/app/dashboard/location-report/components/ReportStats.tsx
+++ b/frontend/app/dashboard/location-report/components/ReportStats.tsx
@@ -24,61 +24,62 @@ function formatCurrency(value: number | undefined | null): string {
 }
 
 export function ReportStats({ stats }: ReportStatsProps) {
+  // Simplified 3-tier color scheme: Red (critical), Amber (severity), Slate (neutral)
   const metrics = [
     {
       label: "Total Crashes",
       value: stats.total_crashes,
-      color: "text-gray-900 dark:text-white",
-      bgColor: "bg-gray-100 dark:bg-gray-700",
+      color: "text-slate-800 dark:text-slate-100",
+      bgColor: "bg-slate-100 dark:bg-slate-700",
     },
     {
       label: "Fatalities",
       value: stats.total_fatalities,
-      color: "text-red-600",
-      bgColor: "bg-red-50 dark:bg-red-900/20",
+      color: "text-red-700 dark:text-red-400",
+      bgColor: "bg-red-50 dark:bg-red-900/30",
       highlight: stats.total_fatalities > 0,
     },
     {
       label: "Incapacitating Injuries",
       value: stats.incapacitating_injuries,
-      color: "text-orange-600",
-      bgColor: "bg-orange-50 dark:bg-orange-900/20",
+      color: "text-amber-700 dark:text-amber-400",
+      bgColor: "bg-amber-50 dark:bg-amber-900/20",
     },
     {
       label: "Total Injuries",
       value: stats.total_injuries,
-      color: "text-yellow-600",
-      bgColor: "bg-yellow-50 dark:bg-yellow-900/20",
+      color: "text-amber-700 dark:text-amber-400",
+      bgColor: "bg-amber-50 dark:bg-amber-900/20",
     },
     {
       label: "Pedestrians Involved",
       value: stats.pedestrians_involved,
-      color: "text-blue-600",
-      bgColor: "bg-blue-50 dark:bg-blue-900/20",
+      color: "text-slate-700 dark:text-slate-300",
+      bgColor: "bg-slate-50 dark:bg-slate-800",
     },
     {
       label: "Cyclists Involved",
       value: stats.cyclists_involved,
-      color: "text-green-600",
-      bgColor: "bg-green-50 dark:bg-green-900/20",
+      color: "text-slate-700 dark:text-slate-300",
+      bgColor: "bg-slate-50 dark:bg-slate-800",
     },
     {
       label: "Hit & Run",
       value: stats.hit_and_run_count,
-      color: "text-purple-600",
-      bgColor: "bg-purple-50 dark:bg-purple-900/20",
+      color: "text-amber-700 dark:text-amber-400",
+      bgColor: "bg-amber-50 dark:bg-amber-900/20",
     },
     {
       label: "Crashes with Injuries",
       value: stats.crashes_with_injuries,
-      color: "text-amber-600",
+      color: "text-amber-700 dark:text-amber-400",
       bgColor: "bg-amber-50 dark:bg-amber-900/20",
     },
     {
       label: "Vehicles Involved",
       value: stats.total_vehicles ?? 0,
-      color: "text-slate-600",
-      bgColor: "bg-slate-50 dark:bg-slate-900/20",
+      color: "text-slate-700 dark:text-slate-300",
+      bgColor: "bg-slate-50 dark:bg-slate-800",
     },
   ];
 
@@ -139,35 +140,16 @@ export function ReportStats({ stats }: ReportStatsProps) {
         </div>
       </div>
 
-      {/* Main Metrics Grid */}
-      <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-9 gap-4 mb-6">
-        {metrics.map((metric) => (
-          <div
-            key={metric.label}
-            className={`${metric.bgColor} rounded-lg shadow-md p-4 ${
-              metric.highlight ? "ring-2 ring-red-500" : ""
-            }`}
-          >
-            <p className="text-xs text-gray-600 dark:text-gray-400 mb-1">
-              {metric.label}
-            </p>
-            <p className={`text-2xl font-bold ${metric.color}`}>
-              {metric.value.toLocaleString()}
-            </p>
-          </div>
-        ))}
-      </div>
-
-      {/* Summary Statistics */}
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
+      {/* Key Insights */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6 mb-6">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
           Key Insights
         </h3>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           {/* Injury Rate */}
           <div className="flex items-center gap-4">
-            <div className="w-16 h-16 rounded-full bg-yellow-100 dark:bg-yellow-900/30 flex items-center justify-center">
-              <span className="text-2xl font-bold text-yellow-600">{injuryRate}%</span>
+            <div className="w-16 h-16 rounded-full bg-amber-100 dark:bg-amber-900/30 flex items-center justify-center">
+              <span className="text-2xl font-bold text-amber-700">{injuryRate}%</span>
             </div>
             <div>
               <p className="text-sm font-medium text-gray-900 dark:text-white">
@@ -182,7 +164,7 @@ export function ReportStats({ stats }: ReportStatsProps) {
           {/* Fatality Rate */}
           <div className="flex items-center gap-4">
             <div className="w-16 h-16 rounded-full bg-red-100 dark:bg-red-900/30 flex items-center justify-center">
-              <span className="text-xl font-bold text-red-600">{fatalityRate}%</span>
+              <span className="text-xl font-bold text-red-700">{fatalityRate}%</span>
             </div>
             <div>
               <p className="text-sm font-medium text-gray-900 dark:text-white">
@@ -196,8 +178,8 @@ export function ReportStats({ stats }: ReportStatsProps) {
 
           {/* Vulnerable Road Users */}
           <div className="flex items-center gap-4">
-            <div className="w-16 h-16 rounded-full bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center">
-              <span className="text-2xl font-bold text-blue-600">
+            <div className="w-16 h-16 rounded-full bg-slate-100 dark:bg-slate-700 flex items-center justify-center">
+              <span className="text-2xl font-bold text-slate-700 dark:text-slate-300">
                 {stats.pedestrians_involved + stats.cyclists_involved}
               </span>
             </div>
@@ -226,10 +208,34 @@ export function ReportStats({ stats }: ReportStatsProps) {
 
       {/* Cost Breakdown Table */}
       {stats.cost_breakdown && (
-        <div className="mt-6">
+        <div className="mb-6">
           <CostBreakdownTable breakdown={stats.cost_breakdown} />
         </div>
       )}
+
+      {/* Detailed Metrics Grid - moved to bottom */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+          Detailed Metrics
+        </h3>
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
+          {metrics.map((metric) => (
+            <div
+              key={metric.label}
+              className={`${metric.bgColor} rounded-lg shadow-sm p-4 ${
+                metric.highlight ? "ring-2 ring-red-500 ring-offset-1" : ""
+              }`}
+            >
+              <p className="text-xs text-gray-600 dark:text-gray-400 mb-1 truncate">
+                {metric.label}
+              </p>
+              <p className={`text-2xl font-bold ${metric.color} tabular-nums text-right`}>
+                {metric.value.toLocaleString()}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Simplify metrics from 8+ colors to 3-tier system (red/amber/slate)
- Fix number alignment with `tabular-nums` and `text-right` classes
- Reduce grid from 9 columns to 5 for cleaner layout
- Reorder sections: Cost → Key Insights → Cost Breakdown → Metrics
- Update Key Insights circles to match new color scheme

Closes #64

## Changes

| Change | Before | After |
|--------|--------|-------|
| **Color scheme** | 8+ colors | 3-tier: Red (critical), Amber (severity), Slate (neutral) |
| **Number alignment** | Unaligned | `tabular-nums text-right` |
| **Grid columns** | `lg:grid-cols-9` | `lg:grid-cols-5` |
| **Layout order** | Cost → Metrics → Insights → Breakdown | Cost → Insights → Breakdown → Metrics |

## Test plan

- [ ] Verify location report page renders correctly
- [ ] Check number alignment in metric cards
- [ ] Confirm 3-tier color scheme displays properly
- [ ] Test responsive layout at different breakpoints
- [ ] Verify dark mode styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)